### PR TITLE
Rm 1.1.0 update

### DIFF
--- a/components/RM/latest/openehr_rm_data_types_110.bmm
+++ b/components/RM/latest/openehr_rm_data_types_110.bmm
@@ -1,14 +1,14 @@
--- 
+--
 -- 	component:   openEHR BMM Implementation Technology Specification
 -- 	description: openEHR RM component formal expression. This file is an ODIN serialisation of
---               the BMM object meta-model classes found at 
+--               the BMM object meta-model classes found at
 --               https://www.openehr.org/releases/LANG/latest/p_bmm.html
 -- 	keywords:    reference model, meta-model, archetypes
 -- 	author:      Thomas Beale <thomas.beale@openEHR.org>
 -- 	support:     https://openehr.atlassian.net/issues/?filter=11117
 -- 	copyright:   Copyright (c) 2009- openEHR Foundation <https://www.openEHR.org>
 -- 	license:     Apache 2.0 <http://www.apache.org/licenses/LICENSE-2.0.html>
--- 
+--
 
 ------------------------------------------------------
 -- BMM version on which these schemas are based.
@@ -31,7 +31,7 @@ rm_release = <"1.1.0">
 ------------------------------------------------------
 schema_revision = <"1.1.0.1">
 schema_lifecycle_state = <"stable">
-schema_description = <"openEHR Release 1.1.0 reference model Data types"> 
+schema_description = <"openEHR Release 1.1.0 reference model Data types">
 schema_author = <"Thomas Beale <thomas.beale@openehr.org>">
 
 ------------------------------------------------------
@@ -61,7 +61,7 @@ packages = <
 			>
 			["quantity"] = <
 				name = <"quantity">
-				classes = <"DV_INTERVAL", "REFERENCE_RANGE", "DV_ORDERED", "DV_QUANTIFIED", "DV_QUANTITY", "DV_PROPORTION", "PROPORTION_KIND", "DV_AMOUNT", "DV_ABSOLUTE_QUANTITY", "DV_COUNT", "DV_ORDINAL">
+				classes = <"DV_INTERVAL", "REFERENCE_RANGE", "DV_ORDERED", "DV_QUANTIFIED", "DV_QUANTITY", "DV_PROPORTION", "PROPORTION_KIND", "DV_AMOUNT", "DV_ABSOLUTE_QUANTITY", "DV_COUNT", "DV_ORDINAL", "DV_SCALE">
 				packages = <
 					["date_time"] = <
 						name = <"date_time">
@@ -249,6 +249,10 @@ class_definitions = <
 				type = <"String">
 				is_mandatory = <True>
 			>
+			["preferred_term"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"preferred_term">
+				type = <"String">
+			>
 		>
 	>
 
@@ -373,6 +377,23 @@ class_definitions = <
 		>
 	>
 
+	["DV_SCALE"] = <
+		name = <"DV_SCALE">
+		ancestors = <"DV_ORDERED", ...>
+		properties = <
+			["value"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"value">
+				type = <"Real">
+				is_mandatory = <True>
+			>
+			["symbol"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"symbol">
+				type = <"DV_CODED_TEXT">
+				is_mandatory = <True>
+			>
+		>
+	>
+
 	["DV_AMOUNT"] = <
 		name = <"DV_AMOUNT">
 		is_abstract = <True>
@@ -421,6 +442,14 @@ class_definitions = <
 				name = <"units">
 				type = <"String">
 				is_mandatory = <True>
+			>
+			["units_system"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"units_system">
+				type = <"String">
+			>
+			["units_display_name"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"units_display_name">
+				type = <"String">
 			>
 			["precision"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"precision">
@@ -736,4 +765,3 @@ class_definitions = <
 	>
 
 >
-

--- a/components/RM/latest/openehr_rm_ehr_110.bmm
+++ b/components/RM/latest/openehr_rm_ehr_110.bmm
@@ -116,6 +116,14 @@ class_definitions = <
 				name = <"directory">
 				type = <"OBJECT_REF">
 			>
+			["folders"] = (P_BMM_CONTAINER_PROPERTY) <
+					name = <"folders">
+					type_def = <
+							container_type = <"List">
+							type = <"OBJECT_REF">
+					>
+					cardinality = <|>=0|>
+			>
 			["compositions"] = (P_BMM_CONTAINER_PROPERTY) <
 				name = <"compositions">
 				type_def = <

--- a/components/RM/latest/openehr_rm_ehr_110.bmm
+++ b/components/RM/latest/openehr_rm_ehr_110.bmm
@@ -1,4 +1,4 @@
--- 
+--
 -- 	component:   openEHR Reference Model (RM)
 -- 	description: openEHR Reference Model schema. This file format is based on the BMM specification
 --  				http://www.openehr.org/releases/BASE/latest/docs/bmm/bmm.html
@@ -7,7 +7,7 @@
 -- 	support:     https://openehr.atlassian.net/projects/SPECPR
 -- 	copyright:   Copyright (c) 2016 openEHR Foundation <https://www.openEHR.org>
 -- 	license:     Apache 2.0 <http://www.apache.org/licenses/LICENSE-2.0.html>
--- 
+--
 
 ------------------------------------------------------
 -- BMM version on which these schemas are based.
@@ -47,11 +47,11 @@ includes = <
 packages = <
 	["org.openehr.rm.ehr"] = <
 		name = <"org.openehr.rm.ehr">
-		classes = <"EHR", "EHR_ACCESS", "EHR_STATUS", "ACCESS_CONTROL_SETTINGS"> 
+		classes = <"EHR", "EHR_ACCESS", "EHR_STATUS", "ACCESS_CONTROL_SETTINGS">
 	>
 	["org.openehr.rm.composition"] = <
 		name = <"org.openehr.rm.composition">
-		classes = <"COMPOSITION", "EVENT_CONTEXT"> 
+		classes = <"COMPOSITION", "EVENT_CONTEXT">
 		packages = <
 			["content"] = <
 				name = <"content">
@@ -59,19 +59,15 @@ packages = <
 				packages = <
 					["navigation"] = <
 						name = <"navigation">
-						classes = <"SECTION", ...> 
+						classes = <"SECTION", ...>
 					>
 					["entry"] = <
 						name = <"entry">
-						classes = <"ENTRY", "CARE_ENTRY", "ADMIN_ENTRY", "OBSERVATION", "EVALUATION", "INSTRUCTION", "ACTION", "ACTIVITY", "ISM_TRANSITION", "INSTRUCTION_DETAILS"> 
+						classes = <"ENTRY", "CARE_ENTRY", "ADMIN_ENTRY", "OBSERVATION", "EVALUATION", "INSTRUCTION", "ACTION", "ACTIVITY", "ISM_TRANSITION", "INSTRUCTION_DETAILS">
 					>
 					["integration"] = <
 						name = <"integration">
-						classes = <"GENERIC_ENTRY"> 
-					>
-					["view"] = <
-						name = <"view">
-						classes = <"VIEW_ITEM", "VIEW_SECTION", "VIEW_ENTRY", "CITATION"> 
+						classes = <"GENERIC_ENTRY">
 					>
 				>
 			>
@@ -139,7 +135,7 @@ class_definitions = <
 			>
 			--
 			-- add this function to create a reachability link from EHR to COMPOSITION, which allows
-			-- correct inference that openEHR-EHR-XXX archetypes can be archetypes of COMPOSITION as 
+			-- correct inference that openEHR-EHR-XXX archetypes can be archetypes of COMPOSITION as
 			-- well as EHR objects
 			--
 			["most_recent_composition"] = (P_BMM_SINGLE_PROPERTY) <
@@ -363,7 +359,7 @@ class_definitions = <
 			>
 		>
 	>
-	
+
 	["CARE_ENTRY"] = <
 		name = <"CARE_ENTRY">
 		is_abstract = <True>
@@ -557,72 +553,4 @@ class_definitions = <
 			>
 		>
 	>
-	
-	--
-	--------------------- rm.view ------------------
-	--
-
-	["VIEW_ITEM"] = <
-		name = <"VIEW_ITEM">
-		ancestors = <"CONTENT_ITEM">
-		properties = <
-			["meta_data"] = (P_BMM_SINGLE_PROPERTY) <
-				name = <"meta_data">
-				type = <"CLUSTER">
-			>
-		>
-	>
-
-	["VIEW_SECTION"] = <
-		name = <"VIEW_SECTION">
-		ancestors = <"VIEW_ITEM">
-		properties = <
-			["items"] = (P_BMM_CONTAINER_PROPERTY) <
-				name = <"items">
-				type_def = <
-					container_type = <"List">
-					type = <"VIEW_ITEM">
-				>
-				cardinality = <|>=0|>
-			>
-		>
-	>
-
-	["VIEW_ENTRY"] = <
-		name = <"VIEW_ENTRY">
-		ancestors = <"VIEW_ITEM">
-	>
-	
-	["CITATION"] = <
-		name = <"CITATION">
-		ancestors = <"VIEW_ENTRY">
-        generic_parameter_defs = <
-            ["T"] = <
-                name = <"T">
-                conforms_to_type = <"ENTRY">
-            >
-        >
-		properties = <
-			["reference"] = (P_BMM_SINGLE_PROPERTY) <
-				name = <"reference">
-				type = <"UID_BASED_ID">
-				is_mandatory = <True>
-			>
-			["parent_reference"] = (P_BMM_SINGLE_PROPERTY) <
-				name = <"parent_reference">
-				type = <"UID_BASED_ID">
-				is_mandatory = <True>
-			>
-			["type"] = (P_BMM_SINGLE_PROPERTY) <
-				name = <"type">
-				type = <"String">
-			>
-			["resolved"] = (P_BMM_SINGLE_PROPERTY_OPEN) <
-				name = <"resolved">
-				type = <"T">
-			>
-		>
-	>
-	
 >
-

--- a/components/RM/latest/openehr_rm_structures_110.bmm
+++ b/components/RM/latest/openehr_rm_structures_110.bmm
@@ -1,14 +1,14 @@
--- 
+--
 -- 	component:   openEHR BMM Implementation Technology Specification
 -- 	description: openEHR Reference Model formal expression. This file is an ODIN serialisation of
---               the BMM object meta-model classes found at 
+--               the BMM object meta-model classes found at
 --               https://www.openehr.org/releases/LANG/latest/p_bmm.html
 -- 	keywords:    reference model, meta-model, archetypes
 -- 	author:      Thomas Beale <thomas.beale@openEHR.org>
 -- 	support:     https://openehr.atlassian.net/issues/?filter=11117
 -- 	copyright:   Copyright (c) 2009- openEHR Foundation <https://www.openEHR.org>
 -- 	license:     Apache 2.0 <http://www.apache.org/licenses/LICENSE-2.0.html>
--- 
+--
 
 ------------------------------------------------------
 -- BMM version on which these schemas are based.
@@ -50,21 +50,21 @@ includes = <
 packages = <
 	["org.openehr.rm.data_structures"] = <
 		name = <"org.openehr.rm.data_structures">
-		classes = <"DATA_STRUCTURE", ...> 
+		classes = <"DATA_STRUCTURE", ...>
 		packages = <
 			["item_structure"] = <
 				name = <"item_structure">
-				classes = <"ITEM_STRUCTURE", "ITEM_SINGLE", "ITEM_TABLE", "ITEM_TREE", "ITEM_LIST"> 
+				classes = <"ITEM_STRUCTURE", "ITEM_SINGLE", "ITEM_TABLE", "ITEM_TREE", "ITEM_LIST">
 				packages = <
 					["representation"] = <
 						name = <"representation">
-						classes = <"ITEM", "CLUSTER", "ELEMENT"> 
+						classes = <"ITEM", "CLUSTER", "ELEMENT">
 					>
 				>
 			>
 			["history"] = <
 				name = <"history">
-				classes = <"HISTORY", "EVENT", "POINT_EVENT", "INTERVAL_EVENT"> 
+				classes = <"HISTORY", "EVENT", "POINT_EVENT", "INTERVAL_EVENT">
 			>
 		>
 	>
@@ -73,19 +73,19 @@ packages = <
 		packages = <
 			["generic"] = <
 				name = <"generic">
-				classes = <"PARTICIPATION", "PARTY_PROXY", "PARTY_SELF", "PARTY_IDENTIFIED", "PARTY_RELATED", "AUDIT_DETAILS", "ATTESTATION", "REVISION_HISTORY", "REVISION_HISTORY_ITEM"> 
+				classes = <"PARTICIPATION", "PARTY_PROXY", "PARTY_SELF", "PARTY_IDENTIFIED", "PARTY_RELATED", "AUDIT_DETAILS", "ATTESTATION", "REVISION_HISTORY", "REVISION_HISTORY_ITEM">
 			>
 			["archetyped"] = <
 				name = <"archetyped">
-				classes = <"PATHABLE", "LOCATABLE", "LINK", "ARCHETYPED", "FEEDER_AUDIT", "FEEDER_AUDIT_DETAILS"> 
+				classes = <"PATHABLE", "LOCATABLE", "LINK", "ARCHETYPED", "FEEDER_AUDIT", "FEEDER_AUDIT_DETAILS">
 			>
 			["change_control"] = <
 				name = <"change_control">
-				classes = <"VERSIONED_OBJECT", "CONTRIBUTION", "VERSION", "ORIGINAL_VERSION", "IMPORTED_VERSION"> 
+				classes = <"VERSIONED_OBJECT", "CONTRIBUTION", "VERSION", "ORIGINAL_VERSION", "IMPORTED_VERSION">
 			>
 			["directory"] = <
 				name = <"directory">
-				classes = <"FOLDER"> 
+				classes = <"FOLDER">
 			>
 		>
 	>
@@ -212,6 +212,10 @@ class_definitions = <
 			["value"] = (P_BMM_SINGLE_PROPERTY) <
 				name = <"value">
 				type = <"DATA_VALUE">
+			>
+			["null_reason"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"null_reason">
+				type = <"DV_TEXT">
 			>
 		>
 	>
@@ -691,6 +695,10 @@ class_definitions = <
 				type = <"String">
 				is_im_runtime = <True>
 			>
+			["other_details"] = (P_BMM_SINGLE_PROPERTY) <
+				name = <"other_details">
+				type = <"ITEM_STRUCTURE">
+			>
 		>
 	>
 
@@ -889,4 +897,3 @@ class_definitions = <
 	>
 
 >
-


### PR DESCRIPTION
Updates to the 1.1.0 BMM files to bring them up to date again with the new to be released specification.

Does contain EHR.folders, even though that is still in review. These BMM files have been validated with Archie, and are included in the work in progress pull request https://github.com/openEHR/archie/pull/220

Removed rm.view package, as that is not referenced anywhere in the 1.1.0 release.